### PR TITLE
Built-in Versioning & Updater scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,16 @@ jobs:
           python -m pip install --upgrade pip pyinstaller
           pip install -r requirements.txt
 
+      - name: Release Versioning
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "__version__='${{github.ref_name}}'" > _version.py
+
+      - name: Nightly Versioning
+        if: true && !startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "__version__='nightly-${{github.sha}}'" > _version.py
+
       - name: Build with pyinstaller
         run: pyinstaller --icon=images/logo.ico --onefile --distpath dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/ --collect-data pyvis --name=twitchcollabnetwork-${{github.ref_name}} main.py
 
@@ -72,6 +82,7 @@ jobs:
       - name: Release Rename
         if: startsWith(github.ref, 'refs/tags/') && !startsWith(matrix.os, 'windows')
         run: |
+          mv dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/twitchcollabnetwork-${{github.ref_name}}.exe dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/twitchcollabnetwork.exe
           mkdir twitchcollabnetwork-${{github.ref_name}}
           mv dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/* twitchcollabnetwork-${{github.ref_name}}/
           zip -r twitchcollabnetwork-${{matrix.os}}-${{github.ref_name}}.zip twitchcollabnetwork-${{github.ref_name}}
@@ -79,6 +90,7 @@ jobs:
       - name: Release Rename - Windows
         if: startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'windows')
         run: |
+          mv dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/twitchcollabnetwork-${{github.ref_name}}.exe dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/twitchcollabnetwork.exe
           mkdir twitchcollabnetwork-${{github.ref_name}}
           mv dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/* twitchcollabnetwork-${{github.ref_name}}/
           7z a twitchcollabnetwork-${{matrix.os}}-${{github.ref_name}}.zip twitchcollabnetwork-${{github.ref_name}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,11 @@ jobs:
         run: pyinstaller --icon=images/logo.ico --onefile --distpath dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/ --collect-data pyvis --name=twitchcollabnetwork main.py
 
       - name: Copy Resources
-        run: mkdir dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/templates && cp templates/* dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/templates/
+        run: |
+          mkdir dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/templates 
+          mkdir dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/updater
+          cp templates/* dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/templates/
+          cp updater/* dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/updater/
 
       - name: Copy Config
         run: cp config.ini dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/config.ini

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,12 @@ jobs:
           echo "__version__='nightly-${{github.sha}}'" > _version.py
 
       - name: Build with pyinstaller
-        run: pyinstaller --icon=images/logo.ico --onefile --distpath dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/ --collect-data pyvis --name=twitchcollabnetwork-${{github.ref_name}} main.py
+        if: true && !startsWith(github.ref, 'refs/tags/')
+        run: pyinstaller --icon=images/logo.ico --onefile --distpath dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/ --collect-data pyvis --name=twitchcollabnetwork-nightly main.py
+
+      - name: Release Build with pyinstaller
+        if: startsWith(github.ref, 'refs/tags/')
+        run: pyinstaller --icon=images/logo.ico --onefile --distpath dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/ --collect-data pyvis --name=twitchcollabnetwork main.py
 
       - name: Copy Resources
         run: mkdir dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/templates && cp templates/* dist/twitchcollabnetwork/${{ matrix.os }}-${{github.ref_name}}/templates/
@@ -82,7 +87,6 @@ jobs:
       - name: Release Rename
         if: startsWith(github.ref, 'refs/tags/') && !startsWith(matrix.os, 'windows')
         run: |
-          mv dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/twitchcollabnetwork-${{github.ref_name}}.exe dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/twitchcollabnetwork.exe
           mkdir twitchcollabnetwork-${{github.ref_name}}
           mv dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/* twitchcollabnetwork-${{github.ref_name}}/
           zip -r twitchcollabnetwork-${{matrix.os}}-${{github.ref_name}}.zip twitchcollabnetwork-${{github.ref_name}}
@@ -90,7 +94,6 @@ jobs:
       - name: Release Rename - Windows
         if: startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'windows')
         run: |
-          mv dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/twitchcollabnetwork-${{github.ref_name}}.exe dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/twitchcollabnetwork.exe
           mkdir twitchcollabnetwork-${{github.ref_name}}
           mv dist/twitchcollabnetwork/${{matrix.os}}-${{github.ref_name}}/* twitchcollabnetwork-${{github.ref_name}}/
           7z a twitchcollabnetwork-${{matrix.os}}-${{github.ref_name}}.zip twitchcollabnetwork-${{github.ref_name}}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ lib/
 *.db
 test.config.ini
 output/
+updater/tmp/
+*.exe
+twitchcollabnetwork
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ Alternatively, click on the [latest action here](https://github.com/WolfwithSwor
 
 Extract the zip to its own folder and make sure it has the executable, templates folder and config.ini. 
 
-Configure the config.ini as per below and you're good to go. As for version updating, update whenever you feel like it by downloading a new portable version and overwrite the application and template folders. For config, migrate your config manually in case new settings were added.
+Configure the config.ini as per below and you're good to go.
+
+For updating, either download a new version from here when a new release is available (overwrite templates and updater folder, and executable. Do not overwrite config.ini), or run an updater script found in the `updater` folder.
+
+For the config, view the latest template here to see if you need to manually migrate or add new settings.
 
 
 # Setup

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ This program supports file/disk based caching. Since this program is used to gen
 - **-o \<filepath>** | **--output_file \<filepath**
   - A filepath to output the generated html to. Must end with '.html'.
   - Can be in a different directory and will automatically copy the lib folder to it if not present. 
+- **-v | --version**
+  - Display the current version of TwitchCollabNetwork 
 
 *Examples*
 

--- a/_version.py
+++ b/_version.py
@@ -1,0 +1,1 @@
+__version__='dev'

--- a/main.py
+++ b/main.py
@@ -18,6 +18,8 @@ from helpers.config import TCNConfig
 from helpers.twitch_utils import TwitchUtils
 from helpers.utils import chunkify, time_since
 
+from _version import __version__
+
 #########
 # Setup #
 #########
@@ -38,7 +40,15 @@ conf_parser = argparse.ArgumentParser(
 )
 conf_parser.add_argument("-c", "--conf_file", help="Specify config file", metavar="FILE")
 conf_parser.add_argument('-o', '--output_file', help="Specify the output file", metavar="FILE")
+conf_parser.add_argument('-v', '--version', action='version', version=f'TwitchCollabNetwork Version: {__version__}')
+
 args, remaining_argv = conf_parser.parse_known_args()
+
+logger.info(f"TwitchCollabManager"
+            f"\nVersion: {__version__}"
+            f"\nBy: WolfwithSword"
+            f"\nhttps://github.com/WolfwithSword/TwitchCollabNetwork"
+            f"\n")
 
 if args.conf_file:
     if os.path.isfile(args.conf_file):

--- a/updater/update.bat
+++ b/updater/update.bat
@@ -1,0 +1,56 @@
+@echo off
+SET latest=
+echo Getting Latest
+set latest_cmd="curl -s https://api.github.com/repos/WolfwithSword/TwitchCollabNetwork/releases/latest | FINDSTR \"tag_name\""
+FOR /F "delims=" %%a IN ('%latest_cmd%') DO SET raw_latest=%%a
+FOR /F "tokens=2" %%a IN ('echo %raw_latest%') DO SET latest=%%a
+set latest=%latest:"=%
+
+set current=
+cd ../
+FOR /F "tokens=3" %%a IN ('"twitchcollabnetwork.exe -v"') DO SET current=%%a
+cd ./updater
+
+
+echo Latest Version: %latest%
+IF "%current%"=="" (
+  echo Current Version: Unknown. May be old, dev, or nightly build
+  echo Please update manually to an officially released build at https://github.com/WolfwithSword/TwitchCollabNetwork/releases/latest
+  timeout 6 > NUL
+  exit
+) ELSE (
+  echo Current Version: %current%
+)
+
+IF "%current%"=="%latest%" (
+  echo "Already up to date..."
+  timeout 2 > NUL
+  exit
+)
+
+if exist ".\tmp\" rd /s /q ".\tmp\"
+
+echo Downloading...
+timeout 1 > NUL
+SET url="https://github.com/WolfwithSword/TwitchCollabNetwork/releases/download/%latest%/twitchcollabnetwork-windows-%latest%.zip"
+SET output="%~dp0tmp\twitchcollabnetwork-%latest%.zip"
+echo %output%
+mkdir "%~dp0tmp"
+bitsadmin /transfer "download-tcn-latest" /download /priority FOREGROUND %url% "%output%"
+powershell -command "Expand-Archive -Force '%output%' '%~dp0tmp\'"
+del %~dp0tmp\twitchcollabnetwork-%latest%\config.ini
+del %~dp0tmp\*.zip
+echo:
+echo Updating...
+echo D|xcopy /s /e /y %~dp0tmp\twitchcollabnetwork-%latest%\ ../
+echo:
+
+echo Done updating TwitchCollabNetwork to %latest%
+echo:
+echo Warning: config.ini was not copied over. Please verify at https://github.com/WolfwithSword/TwitchCollabNetwork/ if any new config items are missing from your existing config.
+echo:
+timeout 4 > NUL
+echo Cleaning up...
+
+if exist ".\tmp\" rd /s /q ".\tmp\"
+timeout 2 > NUL

--- a/updater/update.sh
+++ b/updater/update.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 latest=$(curl -s https://api.github.com/repos/WolfwithSword/TwitchCollabNetwork/releases/latest | grep -i "tag_name" | awk -F '"' '{print $4}')
 current=$("../twitchcollabnetwork" -v | awk '{print $3}')
 

--- a/updater/update.sh
+++ b/updater/update.sh
@@ -1,0 +1,78 @@
+latest=$(curl -s https://api.github.com/repos/WolfwithSword/TwitchCollabNetwork/releases/latest | grep -i "tag_name" | awk -F '"' '{print $4}')
+current=$("../twitchcollabnetwork" -v | awk '{print $3}')
+
+echo "Latest Version: $latest"
+if [[ -z "$current" ]]; then
+  echo "Current Version: Unknown (May be old, dev, or nightly build)"
+  echo "Please update manually to an officially released build at https://github.com/WolfwithSword/TwitchCollabNetwork/releases/latest"
+  sleep 6
+  exit
+else
+  echo "Current Version: $current"
+fi
+
+sleep 2
+
+if [[ "$current" == "$latest" ]]; then
+  echo "Already up to date..."
+  sleep 2
+  exit
+fi
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  platform="ubuntu"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  platform="macos"
+elif [[ "$OSTYPE" == 'cygwin' || "$OSTYPE" == 'win32' || "$OSTYPE" == 'msys' ]]; then
+  platform="windows"
+else
+  platform="unknown"
+fi
+
+if [[ "$platform" == "unknown" ]]; then
+  echo "Unknown platform"
+  echo "Please update manually to an officially released build at https://github.com/WolfwithSword/TwitchCollabNetwork/releases/latest"
+  sleep 6
+  exit
+fi
+
+sleep 2
+
+if [ -d "./tmp" ]; then
+  printf '%s\n' "Removing Lock (./tmp)"
+  rm -rf "./tmp"
+fi
+
+dl_url="https://github.com/WolfwithSword/TwitchCollabNetwork/releases/download/$latest/twitchcollabnetwork-$platform-$latest.zip"
+output="./tmp/twitchcollabnetwork-$platform-$latest.zip"
+
+echo
+echo "Downloading..."
+
+mkdir -p ./tmp
+curl -L $dl_url > $output
+
+echo
+echo "Download complete"
+
+unzip -q $output -d ./tmp -x "twitchcollabnetwork-$latest/config.ini"
+echo $pwd
+
+output="./tmp/$(ls ./tmp | grep ".zip")"
+if [ -e "$output" ]; then
+  rm -rf "$output"
+fi
+#rm "./tmp/$(ls ./tmp | grep ".zip")"
+
+outfolder="./tmp/$(ls ./tmp | awk '{print $1}')/*"
+
+cp -r $outfolder "../"
+sleep 1
+echo "Done updating TwitchCollabNetwork to $latest"
+echo
+echo "Warning: config.ini was not copied over. Please verify at https://github.com/WolfwithSword/TwitchCollabNetwork/ if any new config items are missing from your existing config."
+echo
+sleep 5
+echo "Cleaning up..."
+rm -rf ./tmp
+sleep 1


### PR DESCRIPTION
Introducing a versioning system made to accommodate the workflow builds.

Local versions are `dev`
Commit Action builds or builds from branches are `nightly-commitid`
Release artifacts are versioned after their tag 

Version is synced into the executable by the workflows

Additionally, add a .sh and .bat script to try updating the program in-place. This may need some more testing and tweaking.